### PR TITLE
Removing PCRE from use in this project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,17 +5,10 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 find_package(rustc)
 find_package(rustdoc)
 include(Rust)
-find_package(PCRE)
 
 set(RUSTC_FLAGS "-L${CMAKE_BINARY_DIR}/lib")
 set(RUSTDOC_FLAGS "-L${CMAKE_BINARY_DIR}/lib")
-get_filename_component(PCRE_LIB_LOC ${PCRE_LIBRARIES} PATH)
 
-add_custom_target(
-   rust_pcre
-   COMMAND make
-   WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/rust-pcre"
-)
 add_custom_target(
    rust_mustache
    COMMAND make
@@ -31,31 +24,22 @@ add_custom_target(
 
 file(GLOB libs "${CMAKE_SOURCE_DIR}/rust-*/*/lib*.*")
 
-foreach( file_i ${libs})
-    add_custom_command(
-    TARGET file_i
-    COMMAND ${CMAKE_COMMAND}
-    ARGS -E copy ${file_i} "${CMAKE_BINARY_DIR}/lib/"
-)
-endforeach( file_i )
-set(RUSTC_FLAGS "-L${CMAKE_SOURCE_DIR}/rust-pcre/lib"
-                "-L${CMAKE_SOURCE_DIR}/rust-mustache/build"
+set(RUSTC_FLAGS "-L${CMAKE_SOURCE_DIR}/rust-mustache/build"
                 "-L${CMAKE_SOURCE_DIR}/rust-http/build"
                 "-L${CMAKE_BINARY_DIR}"
-                "-L${PCRE_LIB_LOC}"
               )
 
 rust_crate_auto(src/oxidize.rs
            TARGET_NAME OXIDIZE
-           DEPENDS rust_pcre rust_mustache rust_http ${libs}
+           DEPENDS rust_mustache rust_http ${libs}
            OTHER_RUSTC_FLAGS --crate-type dylib --crate-type rlib)
 
 add_custom_target(oxidize_target
 					ALL
-					DEPENDS ${OXIDIZE_FULL_TARGET} rust_pcre rust_mustache rust_http)
+					DEPENDS ${OXIDIZE_FULL_TARGET} rust_mustache rust_http)
 
 
-add_dependencies(oxidize_target rust_pcre rust_mustache rust_http)
+add_dependencies(oxidize_target rust_mustache rust_http)
 
 #--- example
 

--- a/src/oxidize.rs
+++ b/src/oxidize.rs
@@ -1,7 +1,7 @@
 // don't think this is used anymore
 //extern crate extra;
 // libpcre provides regexs for routing
-extern crate pcre;
+//extern crate pcre;
 // holds references to HashMap
 extern crate collections;
 // need to pass the time info to 

--- a/src/route/mod.rs
+++ b/src/route/mod.rs
@@ -13,5 +13,5 @@ impl Clone for ~Router {
     }
 }
 
-pub mod regexrouter;
+//pub mod regexrouter;
 pub mod trierouter;


### PR DESCRIPTION
This still leaves the regex routing rs file, but this should make it much easier to build without a tricky environment.
