### PR TITLE
This replaces the string url in requests with a rust url

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -1,3 +1,5 @@
+extern crate url;
+
 use http::method::Method;
 use collections::hashmap::HashMap;
 use std::cell::Ref;
@@ -6,7 +8,7 @@ use route::Router;
 #[allow(uppercase_variables)]
 pub struct Request<'a> {
     pub method : Method,
-    pub uri: ~str,
+    pub uri: ~url::Url,
     pub GET : Option<HashMap<~str, ~str>>,
     pub POST : Option<HashMap<~str, ~str>>,
     pub context : Option<HashMap<~str,~str>>,

--- a/src/route/trierouter.rs
+++ b/src/route/trierouter.rs
@@ -16,7 +16,8 @@ pub struct TrieRouter<'a> {
 
 impl<'a> Router for TrieRouter<'a> {
     fn route(&self, request: &mut request::Request, response: &mut ResponseWriter) {
-        let (handler,vars) = self.get_handler(request.uri);
+        
+        let (handler,vars) = self.get_handler(request.uri.path);
         match handler {
             Some(fptr) => (fptr)(request, response, &vars),
             None => debug!("Implement 404 for TrieRouter")


### PR DESCRIPTION
I was going to write some code to make grabbing the queries and fragments easier. Then I saw the url crate that comes with rust. I replaced the constructs where necessary. You can access the queries from a request by request.uri.queries. It's a vector of (~str, ~str). So you can get at what you need easier.
